### PR TITLE
add undocumented data for advance users

### DIFF
--- a/src/plytix_pim_client/dtos/base.py
+++ b/src/plytix_pim_client/dtos/base.py
@@ -1,13 +1,23 @@
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass, fields, field
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class BaseDTO:
+    _undocumented_data: dict = field(default_factory=dict)  # Anything inside may change with no notice
+
     @classmethod
     def from_dict(cls, data: dict):
         _fields = fields(cls)
-        filtered_data = {k: v for k, v in data.items() if k in [f.name for f in _fields]}
-        return cls(**filtered_data)
+        __fields = [f.name for f in _fields if f.name != "_undocumented_data"]
+        filtered_data = {}
+        _undocumented_data = {}
+        for k, v in data.items():
+            if k in __fields:
+                filtered_data[k] = v
+            else:
+                _undocumented_data[k] = v
+
+        return cls(_undocumented_data=_undocumented_data, **filtered_data)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/tests/integration/async_/api/products/product/variants/test_add.py
+++ b/tests/integration/async_/api/products/product/variants/test_add.py
@@ -13,7 +13,9 @@ async def test_add_new_variant_to_product(
     assert result.sku == new_product_data["sku"]
 
     try:
+        # The only asserts about this field, to not spread the undocumented stuff
         assert "_parent_id" in result._undocumented_data
+        assert result._undocumented_data["_parent_id"] == product.id
     except AssertionError:
         warnings.warn("The _parent_id is no longer available in the _undocumented_data, remove this assert.")
 

--- a/tests/integration/async_/api/products/product/variants/test_add.py
+++ b/tests/integration/async_/api/products/product/variants/test_add.py
@@ -1,3 +1,6 @@
+import warnings
+
+
 async def test_add_new_variant_to_product(
     plytix,
     product,
@@ -8,6 +11,11 @@ async def test_add_new_variant_to_product(
     result = await plytix.products.variants.add_variant_to_product(product.id, new_product_data["sku"])
 
     assert result.sku == new_product_data["sku"]
+
+    try:
+        assert "_parent_id" in result._undocumented_data
+    except AssertionError:
+        warnings.warn("The _parent_id is no longer available in the _undocumented_data, remove this assert.")
 
 
 async def test_add_new_variant_to_product_with_label(


### PR DESCRIPTION
Add _undocumented_data for all DTOs to able to work with extra data that is coming but it's not documented in the public API docs, so they may change anytime.