### PR TITLE
Fix relationship filters

### DIFF
--- a/src/plytix_pim_client/api/assets/categories/search.py
+++ b/src/plytix_pim_client/api/assets/categories/search.py
@@ -18,7 +18,7 @@ class AssetCategoriesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[AssetCategory]:
         """
@@ -34,7 +34,7 @@ class AssetCategoriesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class AssetCategoriesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[AssetCategory]:
         """
@@ -80,7 +80,7 @@ class AssetCategoriesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/assets/search.py
+++ b/src/plytix_pim_client/api/assets/search.py
@@ -18,7 +18,7 @@ class AssetsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[Asset]:
         """
@@ -34,7 +34,7 @@ class AssetsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class AssetsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[Asset]:
         """
@@ -80,7 +80,7 @@ class AssetsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/common/search.py
+++ b/src/plytix_pim_client/api/common/search.py
@@ -20,7 +20,7 @@ class SearchResourceAPI(Generic[T]):
         cls,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> PlytixRequest:
         return PlytixRequest(
@@ -30,7 +30,10 @@ class SearchResourceAPI(Generic[T]):
                 "json": {
                     "filters": [[filter_.to_dict() for filter_ in filters_group] for filters_group in filters],
                     "attributes": attributes,
-                    "relationship_filters": [filter_.to_dict() for filter_ in relationship_filters],
+                    "relationship_filters": [
+                        [filter_.to_dict() for filter_ in relationship_filters_group]
+                        for relationship_filters_group in relationship_filters
+                    ],
                     "pagination": {
                         "order": (
                             pagination.sort_by_attribute

--- a/src/plytix_pim_client/api/products/attributes/groups/search.py
+++ b/src/plytix_pim_client/api/products/attributes/groups/search.py
@@ -18,7 +18,7 @@ class ProductAttributesGroupsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductAttributesGroup]:
         """
@@ -34,7 +34,7 @@ class ProductAttributesGroupsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -66,7 +66,7 @@ class ProductAttributesGroupsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductAttributesGroup]:
         """
@@ -82,7 +82,7 @@ class ProductAttributesGroupsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/products/attributes/search.py
+++ b/src/plytix_pim_client/api/products/attributes/search.py
@@ -18,7 +18,7 @@ class ProductAttributesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductAttribute]:
         """
@@ -34,7 +34,7 @@ class ProductAttributesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class ProductAttributesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductAttribute]:
         """
@@ -80,7 +80,7 @@ class ProductAttributesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/products/categories/search.py
+++ b/src/plytix_pim_client/api/products/categories/search.py
@@ -18,7 +18,7 @@ class ProductCategoriesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductCategory]:
         """
@@ -34,7 +34,7 @@ class ProductCategoriesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class ProductCategoriesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductCategory]:
         """
@@ -80,7 +80,7 @@ class ProductCategoriesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/products/families/search.py
+++ b/src/plytix_pim_client/api/products/families/search.py
@@ -18,7 +18,7 @@ class ProductFamiliesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductFamily]:
         """
@@ -34,7 +34,7 @@ class ProductFamiliesSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class ProductFamiliesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductFamily]:
         """
@@ -80,7 +80,7 @@ class ProductFamiliesSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/products/relationships/search.py
+++ b/src/plytix_pim_client/api/products/relationships/search.py
@@ -18,7 +18,7 @@ class ProductRelationshipsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductRelationship]:
         """
@@ -34,7 +34,7 @@ class ProductRelationshipsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -66,7 +66,7 @@ class ProductRelationshipsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[ProductRelationship]:
         """
@@ -82,7 +82,7 @@ class ProductRelationshipsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/src/plytix_pim_client/api/products/search.py
+++ b/src/plytix_pim_client/api/products/search.py
@@ -18,7 +18,7 @@ class ProductsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[Product]:
         """
@@ -34,7 +34,7 @@ class ProductsSearchAPISyncMixin(BaseAPISyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,
@@ -64,7 +64,7 @@ class ProductsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         pagination: Pagination,
     ) -> List[Product]:
         """
@@ -80,7 +80,7 @@ class ProductsSearchAPIAsyncMixin(BaseAPIAsyncMixin):
         self,
         filters: List[List[SearchFilter]],
         attributes: List[str],
-        relationship_filters: List[RelationshipSearchFilter],
+        relationship_filters: List[List[RelationshipSearchFilter]],
         sort_by_attribute: str,
         sort_ascending: bool = True,
         page_size: int = DEFAULT_PAGE_SIZE,

--- a/tests/integration/async_/api/products/test_search.py
+++ b/tests/integration/async_/api/products/test_search.py
@@ -1,4 +1,4 @@
-from plytix_pim_client.dtos.filters import OperatorEnum, SearchFilter
+from plytix_pim_client.dtos.filters import OperatorEnum, RelationshipSearchFilter, SearchFilter
 from plytix_pim_client.dtos.pagination import Pagination
 
 
@@ -74,3 +74,52 @@ async def test_search_all_products(plytix, new_product_data):
 
     assert search_results[2].sku == new_product_data_3["sku"]
     assert search_results[2].label == new_product_data_3["label"]
+
+
+async def test_search_products_by_relationships(plytix, new_product_data, new_product_relationship_data):
+    # Create product 1
+    new_product_data_1 = new_product_data.copy()
+    new_product_data_1["sku"] = f"{new_product_data['sku']}-1"
+    new_product_1 = await plytix.products.create_product(**new_product_data_1)
+
+    # Create product 2 (It won't be linked through the relationship)
+    new_product_data_2 = new_product_data.copy()
+    new_product_data_2["sku"] = f"{new_product_data['sku']}-2"
+    new_product_2 = await plytix.products.create_product(**new_product_data_2)
+
+    # Create product 3
+    new_product_data_3 = new_product_data.copy()
+    new_product_data_3["sku"] = f"{new_product_data['sku']}-3"
+    new_product_3 = await plytix.products.create_product(**new_product_data_3)
+
+    # Create a product relationship
+    relationship = new_product_relationship_data.copy()
+    relationship["name"] = f"{relationship['name']}"
+
+    product_relationship = await plytix.products.relationships.create_product_relationship(**relationship)
+
+    # Link products 1 and 3 through the relationship
+    await plytix.products.relationships.link_product_to_relationship(
+        product_id=new_product_2.id,
+        product_relationship_id=product_relationship.id,
+        product_relationships=[
+            {"product_id": new_product_3.id, "quantity": 7}
+        ]
+    )
+
+    # Search for products by relationship
+    search_results = await plytix.products.search_products(
+        filters=[],
+        attributes=["sku"],
+        relationship_filters=[[
+            RelationshipSearchFilter(
+                relationship_id=product_relationship.id,
+                operator=OperatorEnum.EXISTS,
+                product_ids=[],
+            )
+        ]],
+        pagination=Pagination(page=1, page_size=10, sort_by_attribute="sku", sort_ascending=True)
+    )
+
+    assert len(search_results) == 1
+    assert search_results[0].sku == new_product_data_2["sku"]

--- a/tests/integration/async_/api/products/test_search.py
+++ b/tests/integration/async_/api/products/test_search.py
@@ -77,17 +77,17 @@ async def test_search_all_products(plytix, new_product_data):
 
 
 async def test_search_products_by_relationships(plytix, new_product_data, new_product_relationship_data):
-    # Create product 1
+    # Create product 1 (It won't be linked through the relationship)
     new_product_data_1 = new_product_data.copy()
     new_product_data_1["sku"] = f"{new_product_data['sku']}-1"
     new_product_1 = await plytix.products.create_product(**new_product_data_1)
 
-    # Create product 2 (It won't be linked through the relationship)
+    # Create product 2 (it will be linked to product 3 through the relationship)
     new_product_data_2 = new_product_data.copy()
     new_product_data_2["sku"] = f"{new_product_data['sku']}-2"
     new_product_2 = await plytix.products.create_product(**new_product_data_2)
 
-    # Create product 3
+    # Create product 3 (it will be linked by product 2 through the relationship)
     new_product_data_3 = new_product_data.copy()
     new_product_data_3["sku"] = f"{new_product_data['sku']}-3"
     new_product_3 = await plytix.products.create_product(**new_product_data_3)
@@ -98,7 +98,7 @@ async def test_search_products_by_relationships(plytix, new_product_data, new_pr
 
     product_relationship = await plytix.products.relationships.create_product_relationship(**relationship)
 
-    # Link products 1 and 3 through the relationship
+    # Link products 2 and 3 through the relationship
     await plytix.products.relationships.link_product_to_relationship(
         product_id=new_product_2.id,
         product_relationship_id=product_relationship.id,

--- a/tests/integration/sync/api/products/test_search.py
+++ b/tests/integration/sync/api/products/test_search.py
@@ -77,17 +77,17 @@ def test_search_all_products(plytix, new_product_data):
 
 
 async def test_search_products_by_relationships(plytix, new_product_data, new_product_relationship_data):
-    # Create product 1
+    # Create product 1 (It won't be linked through the relationship)
     new_product_data_1 = new_product_data.copy()
     new_product_data_1["sku"] = f"{new_product_data['sku']}-1"
     new_product_1 = plytix.products.create_product(**new_product_data_1)
 
-    # Create product 2 (It won't be linked through the relationship)
+    # Create product 2 (it will be linked to product 3 through the relationship)
     new_product_data_2 = new_product_data.copy()
     new_product_data_2["sku"] = f"{new_product_data['sku']}-2"
     new_product_2 = plytix.products.create_product(**new_product_data_2)
 
-    # Create product 3
+    # Create product 3 (it will be linked by product 2 through the relationship)
     new_product_data_3 = new_product_data.copy()
     new_product_data_3["sku"] = f"{new_product_data['sku']}-3"
     new_product_3 = plytix.products.create_product(**new_product_data_3)
@@ -98,7 +98,7 @@ async def test_search_products_by_relationships(plytix, new_product_data, new_pr
 
     product_relationship = plytix.products.relationships.create_product_relationship(**relationship)
 
-    # Link products 1 and 3 through the relationship
+    # Link products 2 and 3 through the relationship
     plytix.products.relationships.link_product_to_relationship(
         product_id=new_product_2.id,
         product_relationship_id=product_relationship.id,

--- a/tests/integration/sync/api/products/test_search.py
+++ b/tests/integration/sync/api/products/test_search.py
@@ -1,4 +1,4 @@
-from plytix_pim_client.dtos.filters import OperatorEnum, SearchFilter
+from plytix_pim_client.dtos.filters import OperatorEnum, RelationshipSearchFilter, SearchFilter
 from plytix_pim_client.dtos.pagination import Pagination
 
 
@@ -74,3 +74,52 @@ def test_search_all_products(plytix, new_product_data):
 
     assert search_results[2].sku == new_product_data_3["sku"]
     assert search_results[2].label == new_product_data_3["label"]
+
+
+async def test_search_products_by_relationships(plytix, new_product_data, new_product_relationship_data):
+    # Create product 1
+    new_product_data_1 = new_product_data.copy()
+    new_product_data_1["sku"] = f"{new_product_data['sku']}-1"
+    new_product_1 = plytix.products.create_product(**new_product_data_1)
+
+    # Create product 2 (It won't be linked through the relationship)
+    new_product_data_2 = new_product_data.copy()
+    new_product_data_2["sku"] = f"{new_product_data['sku']}-2"
+    new_product_2 = plytix.products.create_product(**new_product_data_2)
+
+    # Create product 3
+    new_product_data_3 = new_product_data.copy()
+    new_product_data_3["sku"] = f"{new_product_data['sku']}-3"
+    new_product_3 = plytix.products.create_product(**new_product_data_3)
+
+    # Create a product relationship
+    relationship = new_product_relationship_data.copy()
+    relationship["name"] = f"{relationship['name']}"
+
+    product_relationship = plytix.products.relationships.create_product_relationship(**relationship)
+
+    # Link products 1 and 3 through the relationship
+    plytix.products.relationships.link_product_to_relationship(
+        product_id=new_product_2.id,
+        product_relationship_id=product_relationship.id,
+        product_relationships=[
+            {"product_id": new_product_3.id, "quantity": 7}
+        ]
+    )
+
+    # Search for products by relationship
+    search_results = plytix.products.search_products(
+        filters=[],
+        attributes=["sku"],
+        relationship_filters=[[
+            RelationshipSearchFilter(
+                relationship_id=product_relationship.id,
+                operator=OperatorEnum.EXISTS,
+                product_ids=[],
+            )
+        ]],
+        pagination=Pagination(page=1, page_size=10, sort_by_attribute="sku", sort_ascending=True)
+    )
+
+    assert len(search_results) == 1
+    assert search_results[0].sku == new_product_data_2["sku"]


### PR DESCRIPTION
Plytix PIM requires a list of lists of relationship filters, while the current implementation expects a one level list, so the the API call to the PIM doesn't work when sending anything but an empty list.

Although these changes break the current contract, I don't think they should imply a new major version, since the functionality wasn't working before, so it should not break any current integration.